### PR TITLE
Add an option JSON field specifying where to log compressionMessages

### DIFF
--- a/solvers/compression.ml
+++ b/solvers/compression.ml
@@ -952,9 +952,9 @@ let () =
    * with enclosing quotation marks, so we need to strip those too.
    *)
   let cm_out_dir_val = j |> member "cm_out_dir" in
-  match cm_out_dir_val with 
+  match cm_out_dir_val with
   | `Null    -> () ;
-  | _        -> cm_out_dir := String.strip ~drop:(fun c -> Char.equal '"' c) (to_string cm_out_dir_val) ;
+  | _        -> cm_out_dir := String.strip ~drop:(Char.equal '"') (to_string cm_out_dir_val) ;
   ;
 
   (* Not going to do a lot of sanity checking for cm_out_dir, i.e. it better be a valid path

--- a/solvers/compression.ml
+++ b/solvers/compression.ml
@@ -968,6 +968,9 @@ let () =
 
   Printf.eprintf "Will write compression messages to cm_out_dir:  %s\n" !cm_out_dir;
 
+  (* Create the path to write to if it does not already exist *)
+  ignore(Unix.system @@ String.concat ~sep:" " ["mkdir -p"; !cm_out_dir]);
+
   verbose_compression := (try
       j |> member "verbose" |> to_bool
                           with _ -> false);


### PR DESCRIPTION
Title.

~~Note that this WILL THROW AN ERROR IF THE PATH DOES NOT ALREADY EXIST because that is what the existing implementation does. Maybe we should look into calling `mkdir` first if needed? But this seems to be rather nasty in OCaml, which I guess is why the original implementation just assumes that there is a directory called `compressionMessages`...~~

@mlb2251 Thoughts on the field name ~~and whether it's worth putting in the time to do `mdkir`?  With ocaml `4.06` it would involve going through the `Unix` interface which looks doable but a little bit painful (you'd have to `stat` the dir and parse the results to see if it exists and so on). Since `4.12` you can use [Sys.mkdir](https://ocaml.org/api/Sys.html#VALmkdir), which would be less work, but then we'd have to upgrade the ocaml version which might break other things.~~